### PR TITLE
Support InheritableThreadLocal contextHolder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.0.2</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			   <plugin>

--- a/src/main/java/org/springframework/tenancy/context/GlobalTenancyContextHolderStrategy.java
+++ b/src/main/java/org/springframework/tenancy/context/GlobalTenancyContextHolderStrategy.java
@@ -1,0 +1,33 @@
+package org.springframework.tenancy.context;
+
+import org.springframework.util.Assert;
+
+/**
+ * Similar to <code>GlobalSecurityContextHolderStrategy</code>
+ * from Spring Security.
+ */
+public class GlobalTenancyContextHolderStrategy implements TenancyContextHolderStrategy {
+
+    private static TenancyContext contextHolder;
+
+    public void clearContext() {
+        contextHolder = null;
+    }
+
+    public TenancyContext getContext() {
+        if (contextHolder == null) {
+            contextHolder = new DefaultTenancyContext();
+        }
+
+        return contextHolder;
+    }
+
+    public void setContext(TenancyContext context) {
+        Assert.notNull(context, "Only non-null TenancyContext instances are permitted");
+        contextHolder = context;
+    }
+
+    public TenancyContext createEmptyContext() {
+        return new DefaultTenancyContext();
+    }
+}

--- a/src/main/java/org/springframework/tenancy/context/InheritableThreadLocalTenancyContextHolderStrategy.java
+++ b/src/main/java/org/springframework/tenancy/context/InheritableThreadLocalTenancyContextHolderStrategy.java
@@ -1,0 +1,36 @@
+package org.springframework.tenancy.context;
+
+import org.springframework.util.Assert;
+
+/**
+ * Similar to <code>InheritableThreadLocalSecurityContextHolderStrategy</code>
+ * from Spring Security.
+ */
+final class InheritableThreadLocalTenancyContextHolderStrategy implements TenancyContextHolderStrategy {
+
+    private static final ThreadLocal<TenancyContext> CONTEXT_HOLDER = new InheritableThreadLocal<TenancyContext>();
+
+    public void clearContext() {
+        CONTEXT_HOLDER.remove();
+    }
+
+    public TenancyContext getContext() {
+        TenancyContext ctx = CONTEXT_HOLDER.get();
+
+        if (ctx == null) {
+            ctx = createEmptyContext();
+            CONTEXT_HOLDER.set(ctx);
+        }
+
+        return ctx;
+    }
+
+    public void setContext(TenancyContext context) {
+        Assert.notNull(context, "Only non-null TenancyContext instances are permitted");
+        CONTEXT_HOLDER.set(context);
+    }
+
+    public TenancyContext createEmptyContext() {
+        return new DefaultTenancyContext();
+    }
+}

--- a/src/main/java/org/springframework/tenancy/context/TenancyContextHolder.java
+++ b/src/main/java/org/springframework/tenancy/context/TenancyContextHolder.java
@@ -20,6 +20,11 @@
 package org.springframework.tenancy.context;
 
 
+import java.lang.reflect.Constructor;
+
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+
 /**
  * Associates a given {@link TenancyContext} with the current execution.
  * <p>
@@ -27,69 +32,146 @@ package org.springframework.tenancy.context;
  * The purpose of the class is to provide a convenient way to specify the strategy that should be used for a given JVM.
  * This is a JVM-wide setting, since everything in this class is <code>static</code> to facilitate ease of use in
  * calling code.
- * 
+ * <p>
+ * To specify which strategy should be used, you must provide a mode setting. A mode
+ * setting is one of the three valid <code>MODE_</code> settings defined as
+ * <code>static final</code> fields, or a fully qualified classname to a concrete
+ * implementation of
+ * {@link TenancyContextHolderStrategy} that provides a public no-argument constructor.
+ * <p>
+ * There are two ways to specify the desired strategy mode <code>String</code>. The first
+ * is to specify it via the system property keyed on {@link #SYSTEM_PROPERTY}. The second
+ * is to call {@link #setStrategyName(String)} before using the class. If neither approach
+ * is used, the class will default to using {@link #MODE_THREADLOCAL}, which is backwards
+ * compatible, has fewer JVM incompatibilities and is appropriate on servers (whereas
+ * {@link #MODE_GLOBAL} is definitely inappropriate for server use).
+ *
  * @author Clint Morgan (Tasktop Technologies Inc.)
- * 
  */
 public class TenancyContextHolder {
 
-	private static TenancyContextHolderStrategy strategy = new ThreadLocalTenancyContextHolderStrategy();
+    public static final String MODE_THREADLOCAL = "MODE_THREADLOCAL";
 
-	/**
-	 * Explicitly clear the tenacy context.
-	 * 
-	 */
-	public static void clearContext() {
-		strategy.clearContext();
-	}
+    public static final String MODE_INHERITABLETHREADLOCAL = "MODE_INHERITABLETHREADLOCAL";
 
-	/**
-	 * Obtain the current <code>TenancyContext</code>.
-	 * 
-	 * @return the tenancy context (never <code>null</code>)
-	 */
-	public static TenancyContext getContext() {
-		return strategy.getContext();
-	}
+    public static final String MODE_GLOBAL = "MODE_GLOBAL";
 
-	/**
-	 * Associates a new <code>TenancyContext</code> with the current context of execution.
-	 * 
-	 * @param context
-	 *            the new <code>TenancyContext</code> (may not be <code>null</code>)
-	 */
+    public static final String SYSTEM_PROPERTY = "spring.tenancy.strategy";
 
-	public static void setContext(TenancyContext context) {
-		strategy.setContext(context);
-	}
+    private static TenancyContextHolderStrategy strategy = new ThreadLocalTenancyContextHolderStrategy();
 
-	/**
-	 * Delegates the creation of a new, empty context to the configured strategy.
-	 */
-	public static TenancyContext createEmptyContext() {
-		return strategy.createEmptyContext();
-	}
+    private static String strategyName = System.getProperty(SYSTEM_PROPERTY);
 
-	/**
-	 * Allows retrieval of the context strategy.
-	 * 
-	 * @return the configured strategy for storing the tenancy context.
-	 */
-	public static TenancyContextHolderStrategy getStrategy() {
-		return strategy;
-	}
+    private static int initializeCount;
 
-	/**
-	 * Set the context strategy.
-	 * 
-	 * @param strategy
-	 *            the configured strategy for storing the tenancy context.
-	 */
-	public static void setStrategy(TenancyContextHolderStrategy strategy) {
-		if (strategy == null) {
-			throw new IllegalArgumentException();
-		}
-		TenancyContextHolder.strategy = strategy;
-	}
+    static {
+        initialize();
+    }
 
+    /**
+     * Explicitly clear the tenacy context.
+     */
+    public static void clearContext() {
+        strategy.clearContext();
+    }
+
+    /**
+     * Obtain the current <code>TenancyContext</code>.
+     *
+     * @return the tenancy context (never <code>null</code>)
+     */
+    public static TenancyContext getContext() {
+        return strategy.getContext();
+    }
+
+    /**
+     * Associates a new <code>TenancyContext</code> with the current context of execution.
+     *
+     * @param context the new <code>TenancyContext</code> (may not be <code>null</code>)
+     */
+    public static void setContext(TenancyContext context) {
+        strategy.setContext(context);
+    }
+
+    /**
+     * Delegates the creation of a new, empty context to the configured strategy.
+     */
+    public static TenancyContext createEmptyContext() {
+        return strategy.createEmptyContext();
+    }
+
+    /**
+     * Allows retrieval of the context strategy.
+     *
+     * @return the configured strategy for storing the tenancy context.
+     */
+    public static TenancyContextHolderStrategy getStrategy() {
+        return strategy;
+    }
+
+    /**
+     * Set the context strategy.
+     *
+     * @param strategy the configured strategy for storing the tenancy context.
+     */
+    public static void setStrategy(TenancyContextHolderStrategy strategy) {
+        if (strategy == null) {
+            throw new IllegalArgumentException();
+        }
+        TenancyContextHolder.strategy = strategy;
+    }
+
+    /**
+     * Primarily for troubleshooting purposes, this method shows how many times the class
+     * has re-initialized its <code>TenancyContextHolderStrategy</code>.
+     *
+     * @return the count (should be one unless you've called
+     * {@link #setStrategyName(String)} to switch to an alternate strategy.
+     */
+    public static int getInitializeCount() {
+        return initializeCount;
+    }
+
+    private static void initialize() {
+        if (!StringUtils.hasText(strategyName)) {
+            // Set default
+            strategyName = MODE_THREADLOCAL;
+        }
+
+        if (strategyName.equals(MODE_THREADLOCAL)) {
+            strategy = new ThreadLocalTenancyContextHolderStrategy();
+        } else if (strategyName.equals(MODE_INHERITABLETHREADLOCAL)) {
+            strategy = new InheritableThreadLocalTenancyContextHolderStrategy();
+        } else if (strategyName.equals(MODE_GLOBAL)) {
+            strategy = new GlobalTenancyContextHolderStrategy();
+        } else {
+            // Try to load a custom strategy
+            try {
+                Class<?> clazz = Class.forName(strategyName);
+                Constructor<?> customStrategy = clazz.getConstructor();
+                strategy = (TenancyContextHolderStrategy) customStrategy.newInstance();
+            } catch (Exception ex) {
+                ReflectionUtils.handleReflectionException(ex);
+            }
+        }
+
+        initializeCount++;
+    }
+
+    /**
+     * Changes the preferred strategy. Do <em>NOT</em> call this method more than once for
+     * a given JVM, as it will re-initialize the strategy and adversely affect any
+     * existing threads using the old strategy.
+     *
+     * @param strategyName the fully qualified class name of the strategy that should be
+     *                     used.
+     */
+    public static void setStrategyName(String strategyName) {
+        TenancyContextHolder.strategyName = strategyName;
+        initialize();
+    }
+
+    public String toString() {
+        return "TenancyContextHolder[strategy='" + strategyName + "'; initializeCount=" + initializeCount + "]";
+    }
 }

--- a/src/main/java/org/springframework/tenancy/datasource/AbstractDatabaseSwitchingDataSource.java
+++ b/src/main/java/org/springframework/tenancy/datasource/AbstractDatabaseSwitchingDataSource.java
@@ -21,7 +21,9 @@ package org.springframework.tenancy.datasource;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
+import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
@@ -76,6 +78,11 @@ public abstract class AbstractDatabaseSwitchingDataSource implements DataSource 
 	@Override
 	public void setLogWriter(PrintWriter arg0) throws SQLException {
 		wrappedDataSource.setLogWriter(arg0);
+	}
+
+	@Override
+	public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+		return wrappedDataSource.getParentLogger();
 	}
 
 	@Override

--- a/src/test/java/org/springframework/tenancy/context/GlobalTenancyContextHolderStrategyTest.java
+++ b/src/test/java/org/springframework/tenancy/context/GlobalTenancyContextHolderStrategyTest.java
@@ -1,0 +1,24 @@
+package org.springframework.tenancy.context;
+
+import org.junit.After;
+import org.junit.Before;
+import org.springframework.tenancy.provider.DefaultTenant;
+
+public class GlobalTenancyContextHolderStrategyTest extends InheritableThreadLocalTenancyContextHolderStrategyTest {
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        TenancyContextHolder.setStrategyName(TenancyContextHolder.MODE_GLOBAL);
+        TenancyContext tc = new DefaultTenancyContext();
+        tc.setTenant(new DefaultTenant("id", "myTenant"));
+        TenancyContextHolder.setContext(tc);
+
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        TenancyContextHolder.setStrategyName(TenancyContextHolder.MODE_THREADLOCAL);
+    }
+}

--- a/src/test/java/org/springframework/tenancy/context/InheritableThreadLocalTenancyContextHolderStrategyTest.java
+++ b/src/test/java/org/springframework/tenancy/context/InheritableThreadLocalTenancyContextHolderStrategyTest.java
@@ -1,0 +1,36 @@
+package org.springframework.tenancy.context;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.tenancy.provider.DefaultTenant;
+
+public class InheritableThreadLocalTenancyContextHolderStrategyTest extends TenancyContextHolderTest {
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        TenancyContextHolder.setStrategyName(TenancyContextHolder.MODE_INHERITABLETHREADLOCAL);
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        TenancyContextHolder.setStrategyName(TenancyContextHolder.MODE_THREADLOCAL);
+    }
+
+    @Test
+    public void testSpawnThread() throws InterruptedException {
+        TenancyContext tc = new DefaultTenancyContext();
+        tc.setTenant(new DefaultTenant("id", "myTenant"));
+        TenancyContextHolder.setContext(tc);
+        StatusHolder statusHolder = new StatusHolder();
+        Runnable runnable = () -> {
+            statusHolder.assertEquals(tc, TenancyContextHolder.getContext());
+        };
+        Thread thread = new Thread(runnable);
+        thread.start();
+        thread.join(60000L);
+        statusHolder.assertSuccess();
+    }
+}

--- a/src/test/java/org/springframework/tenancy/context/TenancyContextHolderTest.java
+++ b/src/test/java/org/springframework/tenancy/context/TenancyContextHolderTest.java
@@ -1,0 +1,113 @@
+package org.springframework.tenancy.context;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.tenancy.provider.DefaultTenant;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class TenancyContextHolderTest {
+
+    @Before
+    public void setUp() throws Exception {
+        TenancyContextHolder.setStrategyName(TenancyContextHolder.MODE_INHERITABLETHREADLOCAL);
+    }
+
+    @After
+    public void tearDown() {
+        TenancyContextHolder.setStrategyName(TenancyContextHolder.MODE_THREADLOCAL);
+    }
+
+    @Test
+    public void testContextHolderGetterSetterClearer() {
+        TenancyContext tc = new DefaultTenancyContext();
+        tc.setTenant(new DefaultTenant("id", "myTenant"));
+        TenancyContextHolder.setContext(tc);
+        assertThat(TenancyContextHolder.getContext(), is(tc));
+        TenancyContextHolder.clearContext();
+        assertThat(TenancyContextHolder.getContext(), is(not(tc)));
+        TenancyContextHolder.clearContext();
+    }
+
+    @Test
+    public void testNeverReturnsNull() {
+        assertNotNull(TenancyContextHolder.getContext());
+        TenancyContextHolder.clearContext();
+    }
+
+    @Test
+    public void testRejectsNulls() {
+        try {
+            TenancyContextHolder.setContext(null);
+            fail("Should have rejected null");
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    static class StatusHolder {
+
+        private Boolean success;
+
+        private String message;
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public void setSuccess(boolean success) {
+            this.success = success;
+        }
+
+        public void assertEquals(Object expected, Object result) {
+            if (alreadyFailed()) {
+                return;
+            }
+            success = expected == result;
+            addMessageIfFailed("'" + result + "' should be equals to expected value: '" + expected + "'");
+        }
+
+        public void assertNotEquals(Object expected, Object result) {
+            if (alreadyFailed()) {
+                return;
+            }
+            success = expected != result;
+            addMessageIfFailed("'" + result + "' should be different from expected value: '" + expected + "'");
+        }
+
+        public void assertNull(Object expected, Object result) {
+            if (alreadyFailed()) {
+                return;
+            }
+            success = expected != result;
+            addMessageIfFailed("'" + result + "' should be different from expected value: '" + expected + "'");
+        }
+
+        public void assertTrue(String message, boolean expression) {
+            if (alreadyFailed()) {
+                return;
+            }
+            success = expression;
+            if (!success) {
+                this.message = message;
+            }
+        }
+
+        public void addMessageIfFailed(String message) {
+            if (!success) {
+                this.message = message;
+            }
+        }
+
+        public void assertSuccess() {
+            assertTrue(message, success);
+        }
+
+        private boolean alreadyFailed() {
+            return success != null && !success;
+        }
+    }
+}

--- a/src/test/java/org/springframework/tenancy/context/ThreadLocalTenancyContextHolderStrategyTest.java
+++ b/src/test/java/org/springframework/tenancy/context/ThreadLocalTenancyContextHolderStrategyTest.java
@@ -1,0 +1,37 @@
+package org.springframework.tenancy.context;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.tenancy.provider.DefaultTenant;
+
+public class ThreadLocalTenancyContextHolderStrategyTest extends TenancyContextHolderTest {
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        TenancyContextHolder.setStrategyName(TenancyContextHolder.MODE_THREADLOCAL);
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        TenancyContextHolder.setStrategyName(TenancyContextHolder.MODE_THREADLOCAL);
+    }
+
+    @Test
+    public void testSpawnThread() throws InterruptedException {
+        TenancyContext tc = new DefaultTenancyContext();
+        tc.setTenant(new DefaultTenant("id", "myTenant"));
+        TenancyContextHolder.setContext(tc);
+        StatusHolder statusHolder = new StatusHolder();
+        Runnable runnable = () -> {
+            statusHolder.assertNotEquals(tc, TenancyContextHolder.getContext());
+            statusHolder.assertNull(tc, TenancyContextHolder.getContext());
+        };
+        Thread thread = new Thread(runnable);
+        thread.start();
+        thread.join(60000L);
+        statusHolder.assertSuccess();
+    }
+}


### PR DESCRIPTION
Support an InheritableThreadLocal strategy for
tenancyContext just as in Spring Security.

PR for issue #7 