### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 				<repository>
 					<id>EclipseLink Repo</id>
 					<name>EclipseLink Repository</name>
-					<url>http://download.eclipse.org/rt/eclipselink/maven.repo</url>
+					<url>https://download.eclipse.org/rt/eclipselink/maven.repo</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -34,7 +34,7 @@
 		<repository>
 			<id>EclipseLink Repo</id>
 			<name>EclipseLink Repository</name>
-			<url>http://download.eclipse.org/rt/eclipselink/maven.repo</url>
+			<url>https://download.eclipse.org/rt/eclipselink/maven.repo</url>
 		</repository>
 	</repositories>
 
@@ -130,14 +130,14 @@
 		</dependency>
 	</dependencies>
 
-	<url>http://r.tasktop.com/#projects/spring-tenancy</url>
+	<url>https://r.tasktop.com/#projects/spring-tenancy</url>
 	<issueManagement>
 		<system>Code2Cloud</system>
-		<url>http://r.tasktop.com/#projects/spring-tenancy</url>
+		<url>https://r.tasktop.com/#projects/spring-tenancy</url>
 	</issueManagement>
 	<scm>
 		<developerConnection>git@github.com:SpringSource/spring-tenancy.git</developerConnection>
-		<url>http://github.com/SpringSource/spring-tenancy</url>
+		<url>https://github.com/SpringSource/spring-tenancy</url>
 	</scm>
 
 	<build>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://r.tasktop.com/ (UnknownHostException) migrated to:  
  https://r.tasktop.com/ ([https](https://r.tasktop.com/) result UnknownHostException).

## Fixed Success 
These URLs were fixed successfully.

* http://download.eclipse.org/rt/eclipselink/maven.repo migrated to:  
  https://download.eclipse.org/rt/eclipselink/maven.repo ([https](https://download.eclipse.org/rt/eclipselink/maven.repo) result 301).
* http://github.com/SpringSource/spring-tenancy migrated to:  
  https://github.com/SpringSource/spring-tenancy ([https](https://github.com/SpringSource/spring-tenancy) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance