### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.tenancy</groupId>
 	<artifactId>spring-tenancy</artifactId>
@@ -24,7 +24,7 @@
 				<repository>
 					<id>EclipseLink Repo</id>
 					<name>EclipseLink Repository</name>
-					<url>http://download.eclipse.org/rt/eclipselink/maven.repo</url>
+					<url>https://download.eclipse.org/rt/eclipselink/maven.repo</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -34,7 +34,7 @@
 		<repository>
 			<id>EclipseLink Repo</id>
 			<name>EclipseLink Repository</name>
-			<url>http://download.eclipse.org/rt/eclipselink/maven.repo</url>
+			<url>https://download.eclipse.org/rt/eclipselink/maven.repo</url>
 		</repository>
 	</repositories>
 
@@ -130,14 +130,14 @@
 		</dependency>
 	</dependencies>
 
-	<url>http://r.tasktop.com/#projects/spring-tenancy</url>
+	<url>https://r.tasktop.com/#projects/spring-tenancy</url>
 	<issueManagement>
 		<system>Code2Cloud</system>
-		<url>http://r.tasktop.com/#projects/spring-tenancy</url>
+		<url>https://r.tasktop.com/#projects/spring-tenancy</url>
 	</issueManagement>
 	<scm>
 		<developerConnection>git@github.com:SpringSource/spring-tenancy.git</developerConnection>
-		<url>http://github.com/SpringSource/spring-tenancy</url>
+		<url>https://github.com/SpringSource/spring-tenancy</url>
 	</scm>
 
 	<build>

--- a/src/test/resources/org/springframework/tenancy/datasource/DatabaseSwitchingDataSourceTest-context.xml
+++ b/src/test/resources/org/springframework/tenancy/datasource/DatabaseSwitchingDataSourceTest-context.xml
@@ -5,11 +5,11 @@
        xmlns:jee="http://www.springframework.org/schema/jee" 
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-       xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd   
-                           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd   
-                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd   
-                           http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee-3.0.xsd   
-                           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.0.xsd   
+                           http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd   
+                           http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd   
+                           http://www.springframework.org/schema/jee https://www.springframework.org/schema/jee/spring-jee-3.0.xsd   
+                           http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
 
 	<bean
 		class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean"

--- a/src/test/resources/persistence-test-common.xml
+++ b/src/test/resources/persistence-test-common.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" 
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd">
 
     <persistence-unit name="testDomain" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://r.tasktop.com/ (UnknownHostException) with 2 occurrences migrated to:  
  https://r.tasktop.com/ ([https](https://r.tasktop.com/) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/schema/aop/spring-aop-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop-3.0.xsd ([https](https://www.springframework.org/schema/aop/spring-aop-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* http://www.springframework.org/schema/jee/spring-jee-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/jee/spring-jee-3.0.xsd ([https](https://www.springframework.org/schema/jee/spring-jee-3.0.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx-3.0.xsd ([https](https://www.springframework.org/schema/tx/spring-tx-3.0.xsd) result 200).
* http://download.eclipse.org/rt/eclipselink/maven.repo with 2 occurrences migrated to:  
  https://download.eclipse.org/rt/eclipselink/maven.repo ([https](https://download.eclipse.org/rt/eclipselink/maven.repo) result 301).
* http://github.com/SpringSource/spring-tenancy with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-tenancy ([https](https://github.com/SpringSource/spring-tenancy) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd ([https](https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/persistence with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.springframework.org/schema/aop with 2 occurrences
* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/schema/context with 2 occurrences
* http://www.springframework.org/schema/jee with 2 occurrences
* http://www.springframework.org/schema/tx with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences